### PR TITLE
Fix label type

### DIFF
--- a/bigearthnet_common/base.py
+++ b/bigearthnet_common/base.py
@@ -22,7 +22,7 @@ import warnings
 from datetime import datetime
 from importlib import resources
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set, Union
+from typing import Dict, List, Optional, Iterable, Set, Union
 
 import appdirs
 import dateutil
@@ -523,7 +523,7 @@ def _old2new_label(old_label: str) -> Optional[str]:
     return OLD2NEW_LABELS_DICT[old_label]
 
 
-def old2new_labels(old_labels: Sequence[str]) -> Optional[List[str]]:
+def old2new_labels(old_labels: Iterable[str]) -> Optional[List[str]]:
     """
     Converts a list of old-style BigEarthNet labels
     to a list of labels.
@@ -547,9 +547,9 @@ def old2new_labels(old_labels: Sequence[str]) -> Optional[List[str]]:
 
 # Cell
 @validate_arguments
-def ben_19_labels_to_multi_hot(labels: Sequence[str]) -> List[float]:
+def ben_19_labels_to_multi_hot(labels: Iterable[str]) -> List[float]:
     """
-    Convenience function that converts an input sequence of labels into
+    Convenience function that converts an input iterable of labels into
     a multi-hot encoded vector.
     The naturally ordered label list is used as an encoder reference
     - `bigearthnet_common.NEW_LABELS`
@@ -567,9 +567,9 @@ def ben_19_labels_to_multi_hot(labels: Sequence[str]) -> List[float]:
 
 
 @validate_arguments
-def ben_43_labels_to_multi_hot(labels: Sequence[str]) -> List[float]:
+def ben_43_labels_to_multi_hot(labels: Iterable[str]) -> List[float]:
     """
-    Convenience function that converts an input sequence of labels into
+    Convenience function that converts an input iterable of labels into
     a multi-hot encoded vector.
     The naturally ordered label list is used as an encoder reference
     - `bigearthnet_common.OLD_LABELS`

--- a/docs/base.html
+++ b/docs/base.html
@@ -1062,7 +1062,7 @@ cloud/shadow or seasonal snow set or if there exists no 19-label target.</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="old2new_labels" class="doc_header"><code>old2new_labels</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L526" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>old2new_labels</code>(<strong><code>old_labels</code></strong>:<code>Sequence</code>[<code>str</code>])</p>
+<h4 id="old2new_labels" class="doc_header"><code>old2new_labels</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L526" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>old2new_labels</code>(<strong><code>old_labels</code></strong>:<code>Iterable</code>[<code>str</code>])</p>
 </blockquote>
 <p>Converts a list of old-style BigEarthNet labels
 to a list of labels.</p>
@@ -1105,9 +1105,9 @@ then the function will return <code>None</code> and raise a user warning.</p>
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ben_19_labels_to_multi_hot" class="doc_header"><code>ben_19_labels_to_multi_hot</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L549" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ben_19_labels_to_multi_hot</code>(<strong><code>labels</code></strong>:<code>Sequence</code>[<code>str</code>])</p>
+<h4 id="ben_19_labels_to_multi_hot" class="doc_header"><code>ben_19_labels_to_multi_hot</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L549" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ben_19_labels_to_multi_hot</code>(<strong><code>labels</code></strong>:<code>Iterable</code>[<code>str</code>])</p>
 </blockquote>
-<p>Convenience function that converts an input sequence of labels into
+<p>Convenience function that converts an input iterable of labels into
 a multi-hot encoded vector.
 The naturally ordered label list is used as an encoder reference</p>
 <ul>
@@ -1139,9 +1139,9 @@ For example, the "Agro-forestry areas" class is only present in Portugal and in 
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="ben_43_labels_to_multi_hot" class="doc_header"><code>ben_43_labels_to_multi_hot</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L569" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ben_43_labels_to_multi_hot</code>(<strong><code>labels</code></strong>:<code>Sequence</code>[<code>str</code>])</p>
+<h4 id="ben_43_labels_to_multi_hot" class="doc_header"><code>ben_43_labels_to_multi_hot</code><a href="https://github.com/kai-tub/bigearthnet_common/tree/main/bigearthnet_common/base.py#L569" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>ben_43_labels_to_multi_hot</code>(<strong><code>labels</code></strong>:<code>Iterable</code>[<code>str</code>])</p>
 </blockquote>
-<p>Convenience function that converts an input sequence of labels into
+<p>Convenience function that converts an input iterable of labels into
 a multi-hot encoded vector.
 The naturally ordered label list is used as an encoder reference</p>
 <ul>

--- a/justfile
+++ b/justfile
@@ -1,8 +1,6 @@
 install:
 	poetry install
-
-install-kernel:
-	python -m ipykernel install --user
+	poetry run python -m ipykernel install --user
 
 docs:
 	docker-compose up

--- a/nbs/01_base.ipynb
+++ b/nbs/01_base.ipynb
@@ -43,7 +43,7 @@
     "from datetime import datetime\n",
     "from importlib import resources\n",
     "from pathlib import Path\n",
-    "from typing import Dict, List, Optional, Sequence, Set, Union\n",
+    "from typing import Dict, List, Optional, Iterable, Set, Union\n",
     "\n",
     "import appdirs\n",
     "import dateutil\n",
@@ -986,7 +986,7 @@
     "    return OLD2NEW_LABELS_DICT[old_label]\n",
     "\n",
     "\n",
-    "def old2new_labels(old_labels: Sequence[str]) -> Optional[List[str]]:\n",
+    "def old2new_labels(old_labels: Iterable[str]) -> Optional[List[str]]:\n",
     "    \"\"\"\n",
     "    Converts a list of old-style BigEarthNet labels\n",
     "    to a list of labels.\n",
@@ -1053,9 +1053,9 @@
    "source": [
     "# export\n",
     "@validate_arguments\n",
-    "def ben_19_labels_to_multi_hot(labels: Sequence[str]) -> List[float]:\n",
+    "def ben_19_labels_to_multi_hot(labels: Iterable[str]) -> List[float]:\n",
     "    \"\"\"\n",
-    "    Convenience function that converts an input sequence of labels into\n",
+    "    Convenience function that converts an input iterable of labels into\n",
     "    a multi-hot encoded vector.\n",
     "    The naturally ordered label list is used as an encoder reference\n",
     "    - `bigearthnet_common.NEW_LABELS`\n",
@@ -1073,9 +1073,9 @@
     "\n",
     "\n",
     "@validate_arguments\n",
-    "def ben_43_labels_to_multi_hot(labels: Sequence[str]) -> List[float]:\n",
+    "def ben_43_labels_to_multi_hot(labels: Iterable[str]) -> List[float]:\n",
     "    \"\"\"\n",
-    "    Convenience function that converts an input sequence of labels into\n",
+    "    Convenience function that converts an input iterable of labels into\n",
     "    a multi-hot encoded vector.\n",
     "    The naturally ordered label list is used as an encoder reference\n",
     "    - `bigearthnet_common.OLD_LABELS`\n",
@@ -1129,6 +1129,22 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hide\n",
+    "# this should also work for 1-dimensional numpy arrays\n",
+    "import numpy as np\n",
+    "\n",
+    "agro = ben_19_labels_to_multi_hot(np.array([\"Agro-forestry areas\"]))\n",
+    "assert len(agro) == 19\n",
+    "assert agro[0] == 1.0\n",
+    "assert not any(agro[1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1138,8 +1154,8 @@
       "Converted 01_base.ipynb.\n",
       "Converted 02_sets.ipynb.\n",
       "Converted index.ipynb.\n",
+      "converting: /home/kai/git/bigearthnet_common/nbs/00_constants.ipynb\n",
       "converting: /home/kai/git/bigearthnet_common/nbs/01_base.ipynb\n",
-      "converting: /home/kai/git/bigearthnet_common/nbs/02_sets.ipynb\n",
       "converting /home/kai/git/bigearthnet_common/nbs/index.ipynb to README.md\n"
      ]
     }

--- a/poetry.lock
+++ b/poetry.lock
@@ -641,6 +641,14 @@ json-logging = ["json-logging"]
 test = ["pytest", "coverage", "requests", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
+name = "numpy"
+version = "1.21.1"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -1048,7 +1056,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c85bad12ad1895f411c3a7fb12a18b60509406d37e571e82e0a3791b1379ae20"
+content-hash = "6f64db5598f93a2b742be78b3576a167664ecc48b03b6db1211d291ddae0a0c1"
 
 [metadata.files]
 appdirs = [
@@ -1384,6 +1392,36 @@ nest-asyncio = [
 notebook = [
     {file = "notebook-6.4.6-py3-none-any.whl", hash = "sha256:5cad068fa82cd4fb98d341c052100ed50cd69fbfb4118cb9b8ab5a346ef27551"},
     {file = "notebook-6.4.6.tar.gz", hash = "sha256:7bcdf79bd1cda534735bd9830d2cbedab4ee34d8fe1df6e7b946b3aab0902ba3"},
+]
+numpy = [
+    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
+    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
+    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
+    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
+    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
+    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
+    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
+    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
+    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ nbdev = "^1.1"
 jupyter_client = "<6.1.13"
 black = "*"
 isort = "*"
+numpy = "^1.20"
 
 [tool.poetry.scripts]
 ben_constant_prompt = "bigearthnet_common.constants:constants_prompt"


### PR DESCRIPTION
- Strict evaluation of `Sequence` pydantic type leads to validation errors if input is 1-dim np.ndarray
- This should be allowed for easy use in downstream applications, even if it is more dangerous to allow such behaviour
- Requires `np` for testing
- Update justfile to install everything in one step