### PR TITLE
Update python spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [tool.poetry.dependencies]
 # Follow NEP-29
-python = ">=3.8,<=3.10"
+python = ">=3.8,<3.11"
 rich = "^10|^11|^12"
 pydantic = "^1.8"
 fastcore = "^1.3"


### PR DESCRIPTION
- Use <3.11 in pyproject instead of <=3.10 as conda-forge builder otherwise might fail